### PR TITLE
Implement cd, ls

### DIFF
--- a/src/main/kotlin/ru/spbau/mit/Environment.kt
+++ b/src/main/kotlin/ru/spbau/mit/Environment.kt
@@ -1,0 +1,7 @@
+package ru.spbau.mit
+
+import java.nio.file.Paths
+
+class Environment {
+    var currentDirectory: String = Paths.get(".").toAbsolutePath().toString()
+}

--- a/src/main/kotlin/ru/spbau/mit/commands/Cat.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Cat.kt
@@ -1,5 +1,6 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -11,12 +12,13 @@ import java.nio.file.Paths
  * Command prints content of input file
  */
 class Cat : Command {
-    override fun execute(input: String): String {
-        if (!Files.exists(Paths.get(input))) {
+    override fun execute(input: String, env: Environment): String {
+        val path = Paths.get(env.currentDirectory).resolve(input)
+        if (!Files.exists(path)) {
             println(String.format("Error: no such file \'%s\'!", input))
             return ""
         }
 
-        return String(Files.readAllBytes(Paths.get(input)))
+        return String(Files.readAllBytes(path))
     }
 }

--- a/src/main/kotlin/ru/spbau/mit/commands/Cd.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Cd.kt
@@ -1,0 +1,28 @@
+package ru.spbau.mit.commands
+
+import ru.spbau.mit.Environment
+import ru.spbau.mit.splitBy
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * Created by Сева on 27.09.2016.
+ */
+
+class Cd: Command {
+    override fun execute(input: String, env: Environment): String {
+        val args = splitBy(input, ' ')
+        if (args.isEmpty()) {
+            env.currentDirectory = Paths.get("~/").toAbsolutePath().toString()
+            return ""
+        }
+        val file = Paths.get(env.currentDirectory).resolve(args[0]).toFile()
+        if (!file.isDirectory) {
+            System.err.println("cd: ${args[0]} is not an directory")
+            return ""
+        }
+        env.currentDirectory = file.absolutePath
+        return ""
+    }
+
+}

--- a/src/main/kotlin/ru/spbau/mit/commands/Command.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Command.kt
@@ -1,5 +1,7 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
+
 /**
  * Created by rebryk on 9/7/16.
  */
@@ -8,5 +10,5 @@ package ru.spbau.mit.commands
  * Command interface
  */
 interface Command {
-    fun execute(input: String) : String
+    fun execute(input: String, env: Environment) : String
 }

--- a/src/main/kotlin/ru/spbau/mit/commands/Echo.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Echo.kt
@@ -1,5 +1,6 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
 import ru.spbau.mit.unwrap
 
 /**
@@ -10,7 +11,7 @@ import ru.spbau.mit.unwrap
  * Command prints input string to stdout
  */
 class Echo : Command {
-    override fun execute(input: String): String {
+    override fun execute(input: String, env: Environment): String {
         return unwrap(input)
     }
 }

--- a/src/main/kotlin/ru/spbau/mit/commands/ExternalCommand.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/ExternalCommand.kt
@@ -1,5 +1,7 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
+
 /**
  * Created by rebryk on 9/7/16.
  */
@@ -7,8 +9,8 @@ package ru.spbau.mit.commands
 /**
  * Command executes input string in the system shell
  */
-class Environment : Command {
-    override fun execute(input: String): String {
+class ExternalCommand : Command {
+    override fun execute(input: String, env: Environment): String {
         try {
             val process = Runtime.getRuntime().exec(input)
             if (process.waitFor() == 0) {

--- a/src/main/kotlin/ru/spbau/mit/commands/Grep.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Grep.kt
@@ -3,6 +3,7 @@ package ru.spbau.mit.commands
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
+import ru.spbau.mit.Environment
 import ru.spbau.mit.splitBy
 import ru.spbau.mit.unwrap
 import java.nio.file.Files
@@ -61,7 +62,7 @@ class Grep : Command {
         return builder.toString()
     }
 
-    override fun execute(input: String): String {
+    override fun execute(input: String, env: Environment): String {
         val args = splitBy(input, ' ')
 
         val commandLine = try {
@@ -88,11 +89,13 @@ class Grep : Command {
             return ""
         }
 
-        if (!Files.exists(Paths.get(file))) {
+        val path = Paths.get(env.currentDirectory).resolve(file)
+        if (!Files.exists(path)) {
             println(String.format("Error: no such file \'%s\'!", file))
             return "";
         }
 
-        return grep(ignoreCase, wordRegexp, afterContext, pattern, Files.readAllLines(Paths.get(file)))
+        return grep(ignoreCase, wordRegexp, afterContext, pattern,
+                Files.readAllLines(path))
     }
 }

--- a/src/main/kotlin/ru/spbau/mit/commands/Ls.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Ls.kt
@@ -1,0 +1,30 @@
+package ru.spbau.mit.commands
+
+import ru.spbau.mit.Environment
+import ru.spbau.mit.splitBy
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.stream.Collectors
+
+/**
+ * Created by Сева on 27.09.2016.
+ */
+
+class Ls: Command {
+    override fun execute(input: String, env: Environment): String {
+        val args = splitBy(input, ' ')
+        val paths = if (args.isNotEmpty()) args else listOf(".")
+        return paths.map {
+            try {
+                Files.walk(Paths.get(env.currentDirectory).resolve(it), 1).skip(1).map { it.fileName.toString() }
+                        .sorted().collect(Collectors.joining(" "))
+            } catch (e: NoSuchFileException) {
+                System.err.println("ls: $it: no such file or directory")
+                ""
+            } catch (e: Exception) {
+                System.err.println("ls: $it: could not open file or directory")
+                ""
+            }
+        }.filter { it.isNotBlank() }.joinToString(" ")
+    }
+}

--- a/src/main/kotlin/ru/spbau/mit/commands/Pwd.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Pwd.kt
@@ -1,5 +1,8 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
+import java.nio.file.Paths
+
 /**
  * Created by rebryk on 9/7/16.
  */
@@ -8,7 +11,7 @@ package ru.spbau.mit.commands
  * Command that prints current location
  */
 class Pwd : Command {
-    override fun execute(input: String) : String {
-        return System.getProperty("user.dir")
+    override fun execute(input: String, env: Environment): String {
+        return env.currentDirectory
     }
 }

--- a/src/main/kotlin/ru/spbau/mit/commands/Shell.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Shell.kt
@@ -13,9 +13,9 @@ import java.util.*
 class Shell : Command{
     private val commands: MutableMap<String, Command> = HashMap()
     private val variables: MutableMap<String, String> = HashMap()
-    private val environment: Environment = Environment()
+    private val externalCommand: ExternalCommand = ExternalCommand()
 
-    private fun process(input: String) : String {
+    private fun process(input: String, env: Environment) : String {
         if (input.isEmpty()) {
             return input
         }
@@ -28,14 +28,14 @@ class Shell : Command{
         }
 
         if (commands[args[0]] == null) {
-            return environment.execute(args.joinToString(" "));
+            return externalCommand.execute(args.joinToString(" "), env);
         }
 
-        return commands[args[0]]!!.execute(args.subList(1, args.size).joinToString(" "))
+        return commands[args[0]]!!.execute(args.subList(1, args.size).joinToString(" "), env)
     }
 
-    override fun execute(input: String) : String {
-        return splitBy(input, '|').map { processStrings(it, variables) }.fold("", { a, b -> process(b + " " + a) })
+    override fun execute(input: String, env: Environment): String {
+        return splitBy(input, '|').map { processStrings(it, variables) }.fold("", { a, b -> process(b + " " + a, env) })
     }
 
     fun registerCommand(name: String, command: Command) {

--- a/src/main/kotlin/ru/spbau/mit/commands/Wc.kt
+++ b/src/main/kotlin/ru/spbau/mit/commands/Wc.kt
@@ -1,5 +1,7 @@
 package ru.spbau.mit.commands
 
+import ru.spbau.mit.Environment
+
 /**
  * Created by rebryk on 9/7/16.
  */
@@ -8,7 +10,7 @@ package ru.spbau.mit.commands
  * Command counts number of lines, words, characters in the given string
  */
 class Wc : Command {
-    override fun execute(input: String): String {
+    override fun execute(input: String, env: Environment): String {
         var wordsCount = 0
         var linesCount = 0
 

--- a/src/main/kotlin/ru/spbau/mit/main.kt
+++ b/src/main/kotlin/ru/spbau/mit/main.kt
@@ -16,7 +16,10 @@ fun main(args: Array<String>) {
     shell.registerCommand("wc", Wc())
     shell.registerCommand("cat", Cat())
     shell.registerCommand("grep", Grep())
+    shell.registerCommand("ls", Ls())
+    shell.registerCommand("cd", Cd())
 
+    val env = Environment()
     do {
         val line = readLine()
         if (line.orEmpty().compareTo("exit") == 0) {
@@ -24,7 +27,7 @@ fun main(args: Array<String>) {
         }
 
         try {
-            val result = shell.execute(line.orEmpty())
+            val result = shell.execute(line.orEmpty(), env)
             if (result.isNotEmpty()) {
                 println(result)
             }

--- a/src/test/kotlin/ru/spbau/mit/Test.kt
+++ b/src/test/kotlin/ru/spbau/mit/Test.kt
@@ -10,7 +10,8 @@ import kotlin.test.assertEquals
  */
 
 class Test {
-    val shell = Shell()
+    private val shell = Shell()
+    private val env = Environment()
 
     @Before
     fun init() {
@@ -22,17 +23,18 @@ class Test {
 
     @Test
     fun testEcho() {
-        assertEquals("test message", shell.execute("echo 'test message'"))
+        assertEquals("test message", shell.execute("echo 'test message'", env))
     }
 
     @Test
     fun testCat() {
-        shell.execute("file = \'src/main/kotlin/ru/spbau/mit/main.kt\'")
-        assertEquals(shell.execute("cat \$file | wc"), shell.execute("cat src/main/kotlin/ru/spbau/mit/main.kt | wc"))
+        shell.execute("file = \'src/main/kotlin/ru/spbau/mit/main.kt\'", env)
+        assertEquals(shell.execute("cat \$file | wc", env),
+                shell.execute("cat src/main/kotlin/ru/spbau/mit/main.kt | wc", env))
     }
 
     @Test
     fun testGrep() {
-        assertEquals("1 1 34", shell.execute("grep modelVersion pom.xml | wc"))
+        assertEquals("1 1 34", shell.execute("grep modelVersion pom.xml | wc", env))
     }
 }

--- a/src/test/kotlin/ru/spbau/mit/TestCd.kt
+++ b/src/test/kotlin/ru/spbau/mit/TestCd.kt
@@ -1,0 +1,24 @@
+package ru.spbau.mit
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import ru.spbau.mit.commands.Cd
+import kotlin.test.assertEquals
+
+class TestCd {
+    val cd = Cd()
+    val env = Environment()
+
+    @get:Rule
+    private val tmpFolder = TemporaryFolder()
+
+    @Test
+    fun testCd() {
+        tmpFolder.create()
+        val folder = tmpFolder.newFolder("testFolder")
+        cd.execute(folder.absolutePath, env)
+        assertEquals(env.currentDirectory, folder.absolutePath)
+    }
+
+}

--- a/src/test/kotlin/ru/spbau/mit/TestLs.kt
+++ b/src/test/kotlin/ru/spbau/mit/TestLs.kt
@@ -1,0 +1,28 @@
+package ru.spbau.mit
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import ru.spbau.mit.commands.Ls
+import kotlin.test.assertEquals
+
+class TestLs {
+    val ls = Ls()
+    val env = Environment()
+
+    @get:Rule
+    private val tmpFolder = TemporaryFolder()
+
+    @Test
+    fun testCd() {
+        tmpFolder.create()
+
+        val folder = tmpFolder.newFolder("testFolder")
+        tmpFolder.newFile("testFolder/test1")
+        tmpFolder.newFile("testFolder/test2")
+        tmpFolder.newFolder("testFolder", "testFolder")
+
+        assertEquals("test1 test2 testFolder", ls.execute(folder.absolutePath, env))
+    }
+
+}


### PR DESCRIPTION
Код хорошо читаемый, но, к сожалению, местами небольшие проблемы с документацией и архитектурой (впрочем, со всем этим было легко разобраться, посмотрев на реализацию других команд)

Совершенно неочевидно было, почему Environment является командой и вместо того, чтобы хранить переменные или еще что-то в этом роде, он реализует Command и его метод execute запускает внешний процесс. Логика у этого названия была несколько странной.

Не очень понятно, почему парсинг аргументов (в смысле разбиение строки по пробелам, работа с кавычками) перекладывается на реализацию команд. Это приводит к дублированию кода и ко всяким ошибкам (например, `cd test` и `cd "test"` по умолчанию будут себя вести по-разному, если не догадаться про то, что надо к каждому аргументу еще применить функцию `unwrap`.)
Еще такой подход заставляет лишний раз задумываться, надо ли еще самому как-нибудь делать подстановку переменных или еще какие-нибудь действия.
Если уж и перекладывать по каким-то причинам весь парсинг на того, кто реализует команды, то хочется тогда иметь какую-то документацию, которая бы описывала, что надо сделать, чтобы получить то, что хочется.

Пришлось еще немного порефакторить код (добавить таки нормальный Environment + добавить его в сигнатуру execute у Command), чтобы хранить текущую директорию, но проблемой исходного кода это назвать сложно: там можно было обойтись и без этого.

Несколько не хватает тестов, которые бы покрывали все команды. Меняя код, работающий с путями файлов, приходилось руками прогонять какие-то тесты, чтобы проверить, что ничего не сломалось (например, что код будет работать с абсолютными путями вместо относительных, я этот момент чуть не пропустил в одной из команд)
